### PR TITLE
WIP -DO NOT MERGE - HOFF-623: Replace Anchore with Trivy

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -129,6 +129,27 @@ steps:
       branch: master
       event: [push, pull_request]
 
+  # Trivy Security Scannner
+  - name: scan-image
+    pull: always
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
+    resources:
+      limits:
+        cpu: 1000
+        memory: 1024Mi
+    environment:
+      IMAGE_NAME: rra:${DRONE_COMMIT_SHA}
+      SEVERITY: MEDIUM,HIGH,CRITICAL
+      FAIL_ON_DETECTION: false
+      IGNORE_UNFIXED: true
+      ALLOW_CVE_LIST_FILE: hof-services-config/Recruitment-Retention-Allowance/trivy-cve-exceptions.txt
+    when:
+      event:
+      - pull_request
+      - push
+      - tag
+
+
   # Deploy to pull request branch environment
   - name: deploy_to_branch
     pull: if-not-exists
@@ -207,7 +228,7 @@ steps:
   #     branch: master
   #     event: pull_request
 
-  #     # Snyk & Anchore security scans which run after branch deployment to prevent blocking of PR UAT tests
+  # Snyk security scans which run after branch deployment to prevent blocking of PR UAT tests
   # - name: snyk_scan
   #   pull: if-not-exists
   #   image: node:14
@@ -223,17 +244,6 @@ steps:
   #         - feature/*
   #     event: pull_request
 
-  # - name: anchore_scan
-  #   image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/anchore-submission:latest
-  #   pull: always
-  #   environment:
-  #     IMAGE_NAME: firearms:${DRONE_COMMIT_SHA}
-  #     LOCAL_IMAGE: true
-  #     TOLERATE: medium
-  #     WHITELIST_FILE: hof-services-config/Firearms_Licensing/anchore-cve-exceptions.txt
-  #   when:
-  #     branch: master
-  #     event: pull_request
 
     # Deploy to UAT environment
   - name: deploy_to_uat
@@ -326,6 +336,46 @@ steps:
       cron: tear_down_pr_envs
       event: cron
 
+ # CRON job steps that runs security scans using Trivy
+
+  - name: cron_clone_repos
+    image: alpine/git
+    environment:
+      DRONE_GIT_USERNAME:
+        from_secret: drone_git_username
+      DRONE_GIT_TOKEN:
+        from_secret: drone_git_token
+    commands:
+      - git clone https://$${DRONE_GIT_USERNAME}:$${DRONE_GIT_TOKEN}@github.com/UKHomeOfficeForms/hof-services-config.git
+    when:
+      cron: security_scans
+      event: cron
+
+  - name: cron_build_image
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+    commands:
+      - docker build --no-cache -t $${IMAGE_REPO}:$${DRONE_COMMIT_SHA} .
+    volumes:
+      - name: dockersock
+        path: /var/run
+    when:
+      cron: security_scans
+      event: cron
+
+  - name: cron_trivy_scan
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
+    pull: always
+    environment:
+      IMAGE_NAME: rra:${DRONE_COMMIT_SHA}
+      SEVERITY: MEDIUM,HIGH,CRITICAL
+      FAIL_ON_DETECTION: false
+      IGNORE_UNFIXED: true
+      ALLOW_CVE_LIST_FILE: hof-services-config/Recruitment-Retention-Allowance/trivy-cve-exceptions.txt
+    when:
+      cron: security_scans
+      event: cron
+
+
   # Slack notification upon a CRON job fail
   - name: cron_notify_slack_tear_down_pr_envs
     pull: if-not-exists
@@ -347,13 +397,6 @@ steps:
 services:
   - name: docker
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
-
-  # Anchore scanning needs background service to run
-  # - name: anchore-submission-server
-  #   image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/anchore-submission:latest
-  #   pull: always
-  #   commands:
-  #     - /run.sh server
 
   # Redis session setup in background so integration tests can run
   - name: session

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM node:14-alpine@sha256:5c33bc6f021453ae2e393e6e20650a4df0a4737b1882d389f1706
 
 USER root
 
-# Update packages as a result of Anchore security vulnerability checks
 RUN apk update && \
     apk add --upgrade gnutls binutils nodejs nodejs-npm apk-tools libjpeg-turbo libcurl libx11 libxml2
 


### PR DESCRIPTION
What?
 I've added Trivy Scanner to Pipeline and removed deprecated Anchore Scanner for the IMA service, see ticket
[https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-623](url)

Why?
Trivy will let you scan images, file systems and repositories for any vulnerabilities and issues. It will detect CVEs of OS packages, applications susceptibilities, and exposures of IaC in Terraform files, Kubernetes and Docker. Drawback of Anchore Scanner is it’s significantly slower, the process of using it is more cumbersome, the output is less friendly and most importantly, it scans fewer CVEs. 

How?
 Removed Anchore cve exception file and added trivy cve exception file in hof-services-config repo from IMA configs. Removed Anchore Scanner steps from pipeline and added trivy scanner steps with cron scanner. Our Acceptance criteria is to list the Medium to Critical vulnerabilities.

Testing?
We can test it by raising pull request to Master branch. Drone Pipeline should run through the steps and should list the Medium to Critical Vulnerabilties and should progress to next steps of deployment to branch
[https://drone-gh.acp.homeoffice.gov.uk/UKHomeOffice/RRA/231/1/7](url)

Screenshots This screenshot is from Drone CI console
![image](https://github.com/UKHomeOffice/RRA/assets/146218064/e23f3515-8ad4-437a-bd17-3f19036155b0)

